### PR TITLE
fix: contain table overflow and fix Share Link popover clipping on mobile

### DIFF
--- a/src/components/PlannerView.js
+++ b/src/components/PlannerView.js
@@ -66,27 +66,45 @@ export default function PlannerView({ selections, year, onRestart, onBack, onSav
 
   useLayoutEffect(() => {
     if (!sharePopoverVisible || !sharePopoverRef.current) return;
-    const el = sharePopoverRef.current;
 
-    if (window.innerWidth <= 600) {
-      const wrapperRect = shareWrapperRef.current.getBoundingClientRect();
-      el.style.position = 'fixed';
-      el.style.top = `${wrapperRect.bottom + 8}px`;
-      el.style.left = '0.5rem';
-      el.style.right = '0.5rem';
-      el.style.transform = 'none';
-      el.style.minWidth = 'unset';
-      return;
+    function positionSharePopover() {
+      const el = sharePopoverRef.current;
+      if (!el) return;
+
+      if (window.innerWidth <= 600) {
+        const wrapperRect = shareWrapperRef.current.getBoundingClientRect();
+        el.style.position = 'fixed';
+        el.style.top = `${wrapperRect.bottom + 8}px`;
+        el.style.left = '0.5rem';
+        el.style.right = '0.5rem';
+        el.style.transform = 'none';
+        el.style.minWidth = 'unset';
+        return;
+      }
+
+      el.style.position = '';
+      el.style.top = '';
+      el.style.left = '';
+      el.style.right = '';
+      el.style.transform = '';
+      el.style.minWidth = '';
+
+      const rect = el.getBoundingClientRect();
+      const vw = window.innerWidth;
+      if (rect.left < 8) {
+        el.style.transform = `translateX(calc(-50% + ${8 - rect.left}px))`;
+      } else if (rect.right > vw - 8) {
+        el.style.transform = `translateX(calc(-50% + ${vw - 8 - rect.right}px))`;
+      }
     }
 
-    el.style.transform = '';
-    const rect = el.getBoundingClientRect();
-    const vw = window.innerWidth;
-    if (rect.left < 8) {
-      el.style.transform = `translateX(calc(-50% + ${8 - rect.left}px))`;
-    } else if (rect.right > vw - 8) {
-      el.style.transform = `translateX(calc(-50% + ${vw - 8 - rect.right}px))`;
-    }
+    positionSharePopover();
+    window.addEventListener('resize', positionSharePopover);
+    window.addEventListener('orientationchange', positionSharePopover);
+    return () => {
+      window.removeEventListener('resize', positionSharePopover);
+      window.removeEventListener('orientationchange', positionSharePopover);
+    };
   }, [sharePopoverVisible]);
 
   useEffect(() => {

--- a/src/components/PlannerView.js
+++ b/src/components/PlannerView.js
@@ -150,65 +150,67 @@ export default function PlannerView({ selections, year, onRestart, onBack, onSav
           <div className="day-heading-row">
             <span className="day-heading-screen">{day}</span>
           </div>
-          <table className="day-section" data-day={day} data-type={type}>
-            <thead>
-              <tr className="day-heading-print">
-                <th colSpan={stageNames.length + 1}>{day}</th>
-              </tr>
-              <tr>
-                <th>Time</th>
-                {stageNames.map(stg => (
-                  <th key={stg}>{stg}</th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {(() => {
-                const rows = [];
-                const stageEvents = {};
-                stageNames.forEach(stg => {
-                  stageEvents[stg] = mergeOverlapsWithDetail(locations[stg]);
-                });
-                const rowSpanTracker = {};
-
-                for (let tm = timeGrid.start; tm < timeGrid.end; tm += 15) {
-                  const cells = [];
-                  cells.push(
-                    <td className="left-time-col" key={`${day}-time-${tm}`}>
-                      {minutesToTime(tm)}
-                    </td>
-                  );
-
+          <div className="table-scroll-wrap">
+            <table className="day-section" data-day={day} data-type={type}>
+              <thead>
+                <tr className="day-heading-print">
+                  <th colSpan={stageNames.length + 1}>{day}</th>
+                </tr>
+                <tr>
+                  <th>Time</th>
+                  {stageNames.map(stg => (
+                    <th key={stg}>{stg}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {(() => {
+                  const rows = [];
+                  const stageEvents = {};
                   stageNames.forEach(stg => {
-                    if (rowSpanTracker[stg] > 0) {
-                      rowSpanTracker[stg]--;
-                      return;
-                    }
-                    const found = stageEvents[stg].find(
-                      ev => timeToMinutes(ev.start) === tm
-                    );
-                    if (found) {
-                      const span =
-                        (timeToMinutes(found.end) - timeToMinutes(found.start)) / 15;
-                      cells.push(
-                        <td
-                          key={`${day}-${stg}-${tm}`}
-                          rowSpan={span}
-                          dangerouslySetInnerHTML={{ __html: found.name }}
-                        />
-                      );
-                      rowSpanTracker[stg] = span - 1;
-                    } else {
-                      cells.push(<td key={`${day}-${stg}-${tm}`} />);
-                    }
+                    stageEvents[stg] = mergeOverlapsWithDetail(locations[stg]);
                   });
+                  const rowSpanTracker = {};
 
-                  rows.push(<tr key={`${day}-row-${tm}`}>{cells}</tr>);
-                }
-                return rows;
-              })()}
-            </tbody>
-          </table>
+                  for (let tm = timeGrid.start; tm < timeGrid.end; tm += 15) {
+                    const cells = [];
+                    cells.push(
+                      <td className="left-time-col" key={`${day}-time-${tm}`}>
+                        {minutesToTime(tm)}
+                      </td>
+                    );
+
+                    stageNames.forEach(stg => {
+                      if (rowSpanTracker[stg] > 0) {
+                        rowSpanTracker[stg]--;
+                        return;
+                      }
+                      const found = stageEvents[stg].find(
+                        ev => timeToMinutes(ev.start) === tm
+                      );
+                      if (found) {
+                        const span =
+                          (timeToMinutes(found.end) - timeToMinutes(found.start)) / 15;
+                        cells.push(
+                          <td
+                            key={`${day}-${stg}-${tm}`}
+                            rowSpan={span}
+                            dangerouslySetInnerHTML={{ __html: found.name }}
+                          />
+                        );
+                        rowSpanTracker[stg] = span - 1;
+                      } else {
+                        cells.push(<td key={`${day}-${stg}-${tm}`} />);
+                      }
+                    });
+
+                    rows.push(<tr key={`${day}-row-${tm}`}>{cells}</tr>);
+                  }
+                  return rows;
+                })()}
+              </tbody>
+            </table>
+          </div>
         </React.Fragment>
       );
     });

--- a/src/components/PlannerView.js
+++ b/src/components/PlannerView.js
@@ -67,6 +67,18 @@ export default function PlannerView({ selections, year, onRestart, onBack, onSav
   useLayoutEffect(() => {
     if (!sharePopoverVisible || !sharePopoverRef.current) return;
     const el = sharePopoverRef.current;
+
+    if (window.innerWidth <= 600) {
+      const wrapperRect = shareWrapperRef.current.getBoundingClientRect();
+      el.style.position = 'fixed';
+      el.style.top = `${wrapperRect.bottom + 8}px`;
+      el.style.left = '0.5rem';
+      el.style.right = '0.5rem';
+      el.style.transform = 'none';
+      el.style.minWidth = 'unset';
+      return;
+    }
+
     el.style.transform = '';
     const rect = el.getBoundingClientRect();
     const vw = window.innerWidth;

--- a/src/styles/planner/view.css
+++ b/src/styles/planner/view.css
@@ -63,9 +63,16 @@
    PLANNER TABLE
 ───────────────────────────────────────── */
 
+.table-scroll-wrap {
+    width: 100%;
+    overflow-x: auto;
+    margin: 0 0 1.5rem;
+    border-radius: 8px;
+}
+
 table.day-section {
     width: 100%;
-    margin: 0 0 1.5rem;
+    margin: 0;
     border-collapse: collapse;
     background-color: var(--roo-card-bg);
     border-radius: 8px;


### PR DESCRIPTION
## Problem
On mobile, the planner tables could have many stage columns, causing them to expand the full page width. This pushed the toolbar — and all its buttons — off to the right, which in turn caused the Share Link popover to open partially off-screen.

## Changes

### Table overflow containment
- Wrapped each `<table class="day-section">` in a `<div class="table-scroll-wrap">` that uses `overflow-x: auto`
- Tables now scroll independently within their container; the toolbar and page layout stay constrained to the viewport width

### Share Link popover — mobile fix
- On viewports ≤600px, the `useLayoutEffect` now switches the popover to `position: fixed`, measures the button's position via `getBoundingClientRect()`, and pins the popover just below it spanning `0.5rem` from each edge
- This is viewport-relative rather than button-relative, so it works correctly regardless of where the button wraps to in the toolbar