### PR TITLE
Schedule Enhancement and 2026 Data Addition

### DIFF
--- a/public/assets/data/schedules/centeroo_2026.json
+++ b/public/assets/data/schedules/centeroo_2026.json
@@ -1,0 +1,627 @@
+{
+  "Thursday": {
+    "What Stage": [
+      {
+        "name": "Spiritual Cramp",
+        "start": "5:30 PM",
+        "end": "6:30 PM"
+      },
+      {
+        "name": "Vince Staples",
+        "start": "7:00 PM",
+        "end": "8:00 PM"
+      },
+      {
+        "name": "Four Tet",
+        "start": "8:30 PM",
+        "end": "10:00 PM"
+      },
+      {
+        "name": "Skrillex",
+        "start": "10:30 PM",
+        "end": "12:00 AM"
+      }
+    ],
+    "Which Stage": [],
+    "This Tent": [],
+    "That Tent": [],
+    "The Other": [],
+    "Where Stage": []
+  },
+  "Friday": {
+    "What Stage": [
+      {
+        "name": "Villanelle",
+        "start": "1:45 PM",
+        "end": "2:30 PM"
+      },
+      {
+        "name": "Amble",
+        "start": "3:15 PM",
+        "end": "4:00 PM"
+      },
+      {
+        "name": "Blues Traveler",
+        "start": "4:45 PM",
+        "end": "5:45 PM"
+      },
+      {
+        "name": "YUNGBLUD",
+        "start": "6:45 PM",
+        "end": "7:45 PM"
+      },
+      {
+        "name": "GRiZ",
+        "start": "8:45 PM",
+        "end": "10:00 PM"
+      },
+      {
+        "name": "The Strokes",
+        "start": "11:00 PM",
+        "end": "12:15 AM"
+      }
+    ],
+    "Which Stage": [
+      {
+        "name": "Lambrini Girls",
+        "start": "1:15 PM",
+        "end": "2:00 PM"
+      },
+      {
+        "name": "Wolfmother",
+        "start": "2:30 PM",
+        "end": "3:15 PM"
+      },
+      {
+        "name": "bbno$",
+        "start": "4:00 PM",
+        "end": "5:00 PM"
+      },
+      {
+        "name": "Wet Leg",
+        "start": "6:00 PM",
+        "end": "7:00 PM"
+      },
+      {
+        "name": "Jessie Murph",
+        "start": "8:00 PM",
+        "end": "9:00 PM"
+      },
+      {
+        "name": "Mt. Joy",
+        "start": "10:00 PM",
+        "end": "11:00 PM"
+      },
+      {
+        "name": "Turnstile",
+        "start": "12:30 AM",
+        "end": "1:45 AM"
+      }
+    ],
+    "This Tent": [
+      {
+        "name": "PawPaw Rod",
+        "start": "1:30 PM",
+        "end": "2:15 PM"
+      },
+      {
+        "name": "Goldie Boutilier",
+        "start": "2:45 PM",
+        "end": "3:30 PM"
+      },
+      {
+        "name": "Rachel Chinouriri",
+        "start": "4:15 PM",
+        "end": "5:15 PM"
+      },
+      {
+        "name": "Mother Mother",
+        "start": "6:00 PM",
+        "end": "7:00 PM"
+      },
+      {
+        "name": "Smino",
+        "start": "7:45 PM",
+        "end": "8:45 PM"
+      },
+      {
+        "name": "Hot Mulligan",
+        "start": "9:30 PM",
+        "end": "10:30 PM"
+      },
+      {
+        "name": "Lil Jon",
+        "start": "12:45 AM",
+        "end": "2:00 AM"
+      }
+    ],
+    "That Tent": [
+      {
+        "name": "Dora Jar",
+        "start": "1:00 PM",
+        "end": "1:45 PM"
+      },
+      {
+        "name": "Wednesday",
+        "start": "2:30 PM",
+        "end": "3:15 PM"
+      },
+      {
+        "name": "The Chats",
+        "start": "4:00 PM",
+        "end": "4:45 PM"
+      },
+      {
+        "name": "Zack Fox",
+        "start": "5:45 PM",
+        "end": "6:45 PM"
+      },
+      {
+        "name": "Geese",
+        "start": "7:45 PM",
+        "end": "8:45 PM"
+      },
+      {
+        "name": "Blood Orange",
+        "start": "10:00 PM",
+        "end": "11:00 PM"
+      },
+      {
+        "name": "The Dare",
+        "start": "12:15 AM",
+        "end": "1:30 AM"
+      }
+    ],
+    "The Other": [
+      {
+        "name": "Jackie Hollander",
+        "start": "4:00 PM",
+        "end": "5:00 PM"
+      },
+      {
+        "name": "Daniel Allan",
+        "start": "5:15 PM",
+        "end": "6:15 PM"
+      },
+      {
+        "name": "Łaszewo",
+        "start": "6:30 PM",
+        "end": "7:30 PM"
+      },
+      {
+        "name": "NOTION",
+        "start": "7:45 PM",
+        "end": "8:45 PM"
+      },
+      {
+        "name": "Adventure Club",
+        "start": "9:00 PM",
+        "end": "10:00 PM"
+      },
+      {
+        "name": "SIDEPIECE",
+        "start": "10:15 PM",
+        "end": "11:15 PM"
+      },
+      {
+        "name": "Cloonee",
+        "start": "12:00 AM",
+        "end": "1:00 AM"
+      },
+      {
+        "name": "Major Lazer",
+        "start": "1:15 AM",
+        "end": "2:15 AM"
+      },
+      {
+        "name": "Ganja White Night",
+        "start": "2:30 AM",
+        "end": "3:45 AM"
+      },
+      {
+        "name": "INZO (Sunrise Set)",
+        "start": "4:00 AM",
+        "end": "5:15 AM"
+      }
+    ],
+    "Where Stage": [
+      {
+        "name": "ProbCause",
+        "start": "11:15 PM",
+        "end": "12:00 AM"
+      },
+      {
+        "name": "Mary Droppinz",
+        "start": "2:15 AM",
+        "end": "3:00 AM"
+      },
+      {
+        "name": "Richard Finger",
+        "start": "3:15 AM",
+        "end": "4:00 AM"
+      },
+      {
+        "name": "Eazybaked",
+        "start": "4:15 AM",
+        "end": "5:00 AM"
+      },
+      {
+        "name": "Lumasi",
+        "start": "5:15 AM",
+        "end": "6:00 AM"
+      }
+    ]
+  },
+  "Saturday": {
+    "What Stage": [
+      {
+        "name": "Midnight Generation",
+        "start": "1:45 PM",
+        "end": "2:30 PM"
+      },
+      {
+        "name": "Arcy Drive",
+        "start": "3:15 PM",
+        "end": "4:00 PM"
+      },
+      {
+        "name": "Tash Sultana",
+        "start": "4:45 PM",
+        "end": "5:45 PM"
+      },
+      {
+        "name": "Alabama Shakes",
+        "start": "6:45 PM",
+        "end": "7:45 PM"
+      },
+      {
+        "name": "The Neighbourhood",
+        "start": "8:45 PM",
+        "end": "10:00 PM"
+      },
+      {
+        "name": "RÜFÜS DU SOL",
+        "start": "11:10 PM",
+        "end": "12:40 AM"
+      }
+    ],
+    "Which Stage": [
+      {
+        "name": "Steph Strings",
+        "start": "1:15 PM",
+        "end": "2:00 PM"
+      },
+      {
+        "name": "Mountain Grass Unit",
+        "start": "2:30 PM",
+        "end": "3:15 PM"
+      },
+      {
+        "name": "Holly Humberstone",
+        "start": "4:00 PM",
+        "end": "5:00 PM"
+      },
+      {
+        "name": "Amyl and The Sniffers",
+        "start": "5:45 PM",
+        "end": "6:45 PM"
+      },
+      {
+        "name": "Rainbow Kitten Surprise",
+        "start": "7:45 PM",
+        "end": "8:45 PM"
+      },
+      {
+        "name": "Teddy Swims",
+        "start": "9:45 PM",
+        "end": "11:00 PM"
+      },
+      {
+        "name": "\"Weird Al\" Yankovic (Bigger & Weirder Saturday Late Night Rooview)",
+        "start": "12:40 AM",
+        "end": "2:10 AM"
+      }
+    ],
+    "This Tent": [
+      {
+        "name": "Sunami",
+        "start": "12:45 PM",
+        "end": "1:30 PM"
+      },
+      {
+        "name": "Congress The Band",
+        "start": "2:00 PM",
+        "end": "2:45 PM"
+      },
+      {
+        "name": "Waylon Wyatt",
+        "start": "3:30 PM",
+        "end": "4:15 PM"
+      },
+      {
+        "name": "The Runarounds",
+        "start": "5:00 PM",
+        "end": "6:00 PM"
+      },
+      {
+        "name": "Passion Pit",
+        "start": "6:45 PM",
+        "end": "7:45 PM"
+      },
+      {
+        "name": "Kesha Presents: Superjâm Esoterica (The Alchemy of Pop)",
+        "start": "8:45 PM",
+        "end": "10:30 PM"
+      },
+      {
+        "name": "Osees",
+        "start": "12:30 AM",
+        "end": "1:30 AM"
+      },
+      {
+        "name": "Snow Strippers",
+        "start": "2:00 AM",
+        "end": "2:45 AM"
+      }
+    ],
+    "That Tent": [
+      {
+        "name": "The Stews",
+        "start": "1:00 PM",
+        "end": "1:45 PM"
+      },
+      {
+        "name": "Confidence Man",
+        "start": "2:30 PM",
+        "end": "3:15 PM"
+      },
+      {
+        "name": "Trixie Mattel",
+        "start": "4:00 PM",
+        "end": "4:45 PM"
+      },
+      {
+        "name": "Wyatt Flores",
+        "start": "5:45 PM",
+        "end": "6:45 PM"
+      },
+      {
+        "name": "SG Lewis",
+        "start": "7:45 PM",
+        "end": "8:45 PM"
+      },
+      {
+        "name": "flipturn",
+        "start": "10:00 PM",
+        "end": "11:00 PM"
+      },
+      {
+        "name": "Freddie Gibbs & The Alchemist",
+        "start": "12:50 AM",
+        "end": "2:05 AM"
+      }
+    ],
+    "The Other": [
+      {
+        "name": "Nikita, the Wicked",
+        "start": "3:45 PM",
+        "end": "4:45 PM"
+      },
+      {
+        "name": "Juelz",
+        "start": "5:00 PM",
+        "end": "6:00 PM"
+      },
+      {
+        "name": "Deathpact",
+        "start": "6:15 PM",
+        "end": "7:15 PM"
+      },
+      {
+        "name": "Boys Noize",
+        "start": "7:30 PM",
+        "end": "8:30 PM"
+      },
+      {
+        "name": "Sub Focus",
+        "start": "8:45 PM",
+        "end": "9:45 PM"
+      },
+      {
+        "name": "Sara Landry",
+        "start": "10:00 PM",
+        "end": "11:00 PM"
+      },
+      {
+        "name": "Chase & Status",
+        "start": "12:40 AM",
+        "end": "1:55 AM"
+      },
+      {
+        "name": "Gorgon City (Sunrise Set)",
+        "start": "2:15 AM",
+        "end": "5:15 AM"
+      }
+    ],
+    "Where Stage": [
+      {
+        "name": "Steve & Cory Are Dead",
+        "start": "6:30 PM",
+        "end": "8:00 PM"
+      },
+      {
+        "name": "Costa",
+        "start": "11:30 PM",
+        "end": "12:15 AM"
+      },
+      {
+        "name": "CloZee",
+        "start": "2:45 AM",
+        "end": "3:30 AM"
+      },
+      {
+        "name": "Big Gigantic",
+        "start": "3:45 AM",
+        "end": "4:30 AM"
+      },
+      {
+        "name": "Smoakland",
+        "start": "4:45 AM",
+        "end": "5:30 AM"
+      },
+      {
+        "name": "Effin",
+        "start": "5:45 AM",
+        "end": "6:30 AM"
+      }
+    ]
+  },
+  "Sunday": {
+    "What Stage": [
+      {
+        "name": "Aly & AJ",
+        "start": "2:15 PM",
+        "end": "3:00 PM"
+      },
+      {
+        "name": "Trombone Shorty",
+        "start": "3:45 PM",
+        "end": "4:45 PM"
+      },
+      {
+        "name": "Tedeschi Trucks Band",
+        "start": "5:30 PM",
+        "end": "6:30 PM"
+      },
+      {
+        "name": "Role Model",
+        "start": "7:30 PM",
+        "end": "8:30 PM"
+      },
+      {
+        "name": "Noah Kahan",
+        "start": "9:30 PM",
+        "end": "11:00 PM"
+      }
+    ],
+    "Which Stage": [
+      {
+        "name": "Little Stranger",
+        "start": "1:15 PM",
+        "end": "2:00 PM"
+      },
+      {
+        "name": "Spacey Jane",
+        "start": "2:45 PM",
+        "end": "3:45 PM"
+      },
+      {
+        "name": "Japanese Breakfast",
+        "start": "4:30 PM",
+        "end": "5:30 PM"
+      },
+      {
+        "name": "Clipse",
+        "start": "6:30 PM",
+        "end": "7:30 PM"
+      },
+      {
+        "name": "Kesha",
+        "start": "8:30 PM",
+        "end": "9:30 PM"
+      }
+    ],
+    "This Tent": [
+      {
+        "name": "Nat Myers",
+        "start": "12:30 PM",
+        "end": "1:15 PM"
+      },
+      {
+        "name": "Buffalo Traffic Jam",
+        "start": "1:45 PM",
+        "end": "2:30 PM"
+      },
+      {
+        "name": "Hemlocke Springs",
+        "start": "3:20 PM",
+        "end": "4:00 PM"
+      },
+      {
+        "name": "Fcukers",
+        "start": "4:45 PM",
+        "end": "5:45 PM"
+      },
+      {
+        "name": "Turnover",
+        "start": "6:30 PM",
+        "end": "7:30 PM"
+      },
+      {
+        "name": "Modest Mouse",
+        "start": "8:15 PM",
+        "end": "9:30 PM"
+      }
+    ],
+    "That Tent": [
+      {
+        "name": "Girl Tones",
+        "start": "1:30 PM",
+        "end": "2:15 PM"
+      },
+      {
+        "name": "Blondshell",
+        "start": "3:00 PM",
+        "end": "3:45 PM"
+      },
+      {
+        "name": "Audrey Hobert",
+        "start": "4:45 PM",
+        "end": "5:30 PM"
+      },
+      {
+        "name": "Del Water Gap",
+        "start": "6:30 PM",
+        "end": "7:30 PM"
+      },
+      {
+        "name": "Mariah the Scientist",
+        "start": "8:30 PM",
+        "end": "9:30 PM"
+      }
+    ],
+    "The Other": [
+      {
+        "name": "Motifv",
+        "start": "1:45 PM",
+        "end": "2:45 PM"
+      },
+      {
+        "name": "A Hundred Drums",
+        "start": "3:00 PM",
+        "end": "4:00 PM"
+      },
+      {
+        "name": "San Holo",
+        "start": "4:15 PM",
+        "end": "5:15 PM"
+      },
+      {
+        "name": "Big Gigantic",
+        "start": "5:30 PM",
+        "end": "6:30 PM"
+      },
+      {
+        "name": "Daily Bread",
+        "start": "6:45 PM",
+        "end": "7:45 PM"
+      },
+      {
+        "name": "LSZEE",
+        "start": "8:15 PM",
+        "end": "9:30 PM"
+      }
+    ],
+    "Where Stage": []
+  }
+}

--- a/public/assets/print-planner.css
+++ b/public/assets/print-planner.css
@@ -106,6 +106,23 @@
         break-before: page;
     }
 
+    .day-heading-compact {
+        display: flex !important;
+        margin: 8pt 0 4pt !important;
+    }
+
+    .day-heading-compact .day-heading-screen {
+        display: block !important;
+        font-size: 13pt;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+    }
+
+    .day-select-badge {
+        display: none !important;
+    }
+
     .compact-event-card {
         border: 1px solid #bbb !important;
         border-left: 3px solid #000 !important;

--- a/src/components/PlannerBuilder.js
+++ b/src/components/PlannerBuilder.js
@@ -4,11 +4,10 @@ import YearSelector from './YearSelector';
 import TabContainer from './TabContainer';
 import SelectionGrid from './SelectionGrid';
 import { getBonnarooStatus } from '../utils/bonnarooStatus';
-import { SCHEDULE_NOT_AVAILABLE_TEMPLATE } from '../config';
+import { SCHEDULE_NOT_AVAILABLE_TEMPLATE, PARTIAL_SCHEDULE_NOT_AVAILABLE_TEMPLATE } from '../config';
 import { detectConflicts } from '../utils/conflictUtils';
 
-function getStatusClass(roostatus, scheduleMissing) {
-  if (scheduleMissing) return 'bonnaroo-status bonnaroo-status--not-available';
+function getStatusClass(roostatus) {
   if (!roostatus) return 'bonnaroo-status';
   if (roostatus.includes('has ended')) return 'bonnaroo-status bonnaroo-status--ended';
   if (roostatus.includes('has begun')) return 'bonnaroo-status bonnaroo-status--started';
@@ -31,8 +30,10 @@ export default function PlannerBuilder({
   const hasInitializedSchedule = useRef(false);
 
   useEffect(() => {
-    setScheduleData(initialSchedule || { Centeroo: null, Outeroo: null });
-    setActiveTab('Centeroo');
+    const newData = initialSchedule || { Centeroo: null, Outeroo: null };
+    setScheduleData(newData);
+    const centerooAvail = newData.Centeroo && Object.keys(newData.Centeroo).length > 0;
+    setActiveTab(centerooAvail ? 'Centeroo' : 'Outeroo');
     if (hasInitializedSchedule.current) {
       // Year changed after initial mount — clear selections for the new year
       setCurrentSelections([]);
@@ -56,6 +57,11 @@ export default function PlannerBuilder({
     }),
     [currentSelections]
   );
+
+  const centerooAvailable =
+    !!scheduleData.Centeroo && Object.keys(scheduleData.Centeroo).length > 0;
+  const outerooAvailable =
+    !!scheduleData.Outeroo && Object.keys(scheduleData.Outeroo).length > 0;
 
   function toggleSelection(payload) {
     setCurrentSelections(prev => {
@@ -84,7 +90,8 @@ export default function PlannerBuilder({
   }
 
   function selectAll() {
-    if (!scheduleData[activeTab]) return;
+    const isAvail = activeTab === 'Centeroo' ? centerooAvailable : outerooAvailable;
+    if (!isAvail) return;
     const all = [];
     const data = scheduleData[activeTab];
     Object.entries(data).forEach(([day, locations]) => {
@@ -116,13 +123,9 @@ export default function PlannerBuilder({
     return null;
   }
 
-  const scheduleMissing =
-    !scheduleData.Centeroo ||
-    !scheduleData.Outeroo ||
-    Object.keys(scheduleData.Centeroo).length === 0 ||
-    Object.keys(scheduleData.Outeroo).length === 0;
+  const bothMissing = !centerooAvailable && !outerooAvailable;
 
-  if (scheduleMissing) {
+  if (bothMissing) {
     return (
       <>
         <div className="builder-toolbar">
@@ -138,9 +141,11 @@ export default function PlannerBuilder({
   }
 
   const roostatus = getBonnarooStatus(year, scheduleData);
-  const statusClass = getStatusClass(roostatus, scheduleMissing);
+  const statusClass = getStatusClass(roostatus);
   const totalCount = currentSelections.length;
   const conflictCount = conflictKeys.size;
+  const activeTabAvailable = activeTab === 'Centeroo' ? centerooAvailable : outerooAvailable;
+  const inactiveTab = activeTab === 'Centeroo' ? 'Outeroo' : 'Centeroo';
 
   return (
     <>
@@ -183,7 +188,7 @@ export default function PlannerBuilder({
         </button>
       </div>
 
-      {scheduleData[activeTab] && (
+      {activeTabAvailable ? (
         <SelectionGrid
           data={scheduleData[activeTab]}
           type={activeTab}
@@ -191,6 +196,13 @@ export default function PlannerBuilder({
           onToggleSelection={toggleSelection}
           conflictKeys={conflictKeys}
         />
+      ) : (
+        <p className="bonnaroo-status bonnaroo-status--not-available">
+          {PARTIAL_SCHEDULE_NOT_AVAILABLE_TEMPLATE
+            .replace('{missing}', activeTab)
+            .replace('{year}', year)
+            .replace(/\{available\}/g, inactiveTab)}
+        </p>
       )}
 
       <div className="builder-bottom-padding" />

--- a/src/components/PlannerBuilder.js
+++ b/src/components/PlannerBuilder.js
@@ -24,8 +24,12 @@ export default function PlannerBuilder({
   lastModified,
   onLoad
 }) {
-  const [scheduleData, setScheduleData] = useState({ Centeroo: null, Outeroo: null });
-  const [activeTab, setActiveTab] = useState('Centeroo');
+  const [scheduleData, setScheduleData] = useState(() => initialSchedule || { Centeroo: null, Outeroo: null });
+  const [activeTab, setActiveTab] = useState(() => {
+    const data = initialSchedule || { Centeroo: null, Outeroo: null };
+    const centerooAvail = data.Centeroo && Object.keys(data.Centeroo).length > 0;
+    return centerooAvail ? 'Centeroo' : 'Outeroo';
+  });
   const [currentSelections, setCurrentSelections] = useState(() => initialSelections || []);
   const hasInitializedSchedule = useRef(false);
 

--- a/src/components/PlannerView.js
+++ b/src/components/PlannerView.js
@@ -265,7 +265,7 @@ export default function PlannerView({ selections, year, onRestart, onBack, onSav
 
     return Object.entries(byDay).map(([day, daySelections]) => (
       <React.Fragment key={`compact-${type}-${day}`}>
-        <div className="day-heading-row">
+        <div className="day-heading-row day-heading-compact">
           <span className="day-heading-screen">{day}</span>
           <span className="day-select-badge">{daySelections.length} selected</span>
         </div>

--- a/src/config.js
+++ b/src/config.js
@@ -109,6 +109,12 @@ export const BONNAROO_STATUS_STARTED_TEMPLATE = 'Bonnaroo {year} has begun!';
 // -------------------------------------------------
 export const SCHEDULE_NOT_AVAILABLE_TEMPLATE = 'The schedule for {year} is not available yet. Check back once Bonnaroo releases the official schedule.';
 
+// -------------------------------------------------
+// Shown when only one of the two schedules is available.
+// {missing} = unavailable tab name, {available} = available tab name, {year} = festival year
+// -------------------------------------------------
+export const PARTIAL_SCHEDULE_NOT_AVAILABLE_TEMPLATE = 'The {missing} schedule for {year} is not yet available. Check back once Bonnaroo releases the official schedule. The {available} schedule is available — switch to the {available} tab.';
+
 // --- Export filenames --------------------------------
 
 export const PDF_FILENAME_TEMPLATE = 'Bonnaroo_{year}_Planner_{label}_{orientation}.pdf';

--- a/src/utils/scheduleUtils.js
+++ b/src/utils/scheduleUtils.js
@@ -26,10 +26,8 @@ export async function fetchSchedule(year) {
   }
 
   const exists =
-    centerooResp.ok &&
-    outerooResp.ok &&
-    Object.keys(centeroo).length > 0 &&
-    Object.keys(outeroo).length > 0;
+    (centerooResp.ok && Object.keys(centeroo).length > 0) ||
+    (outerooResp.ok && Object.keys(outeroo).length > 0);
 
   // Get latest Last-Modified
   const lmCent = centerooResp.headers.get('Last-Modified');


### PR DESCRIPTION
### Description

This release enhances schedule handling for partial availability scenarios and adds 2026 Bonnaroo schedule data. The application now gracefully supports situations where only one stage schedule (Centeroo or Outeroo) is available, improving user experience when the festival releases staggered schedule information.

### Changes

#### New Features
- **2026 Schedule Data:** Added complete Centeroo schedule for 2026 with Thursday through Sunday programming
- **Partial Schedule Support:** App now handles cases where only Centeroo or Outeroo schedule is available, automatically switching to the available tab
- **Enhanced User Messaging:** New template message guides users when only one schedule is available

#### Improvements
- **Schedule Detection Logic:** Refactored `fetchSchedule()` to accept partial schedules—no longer requires both Centeroo and Outeroo to be available
- **Smarter Tab Switching:** PlannerBuilder now intelligently defaults to whichever tab has schedule data available
- **Print CSS Refinements:** Fixed compact view styling with improved day heading display and badge handling

### Files Modified

- `public/assets/data/schedules/centeroo_2026.json` — (NEW) Complete 2026 Centeroo schedule
- `src/components/PlannerBuilder.js` — Enhanced availability detection and partial schedule handling
- `src/components/PlannerView.js` — Updated compact print view styling
- `src/config.js` — Added `PARTIAL_SCHEDULE_NOT_AVAILABLE_TEMPLATE` message
- `src/utils/scheduleUtils.js` — Refactored schedule availability logic
- `public/assets/print-planner.css` — Fixed compact view styling for print media

### Backward Compatibility

Fully backward compatible. All changes are additive and improve existing functionality.